### PR TITLE
[PWA-407] Cannot Deploy PWA Develop & Core Develop (2.3-develop) Git Branches to Cloud Due to Composer Requirement Issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     },
     "require": {
         "php": "~7.1.3||~7.2.0||~7.3.0",
-        "magento/framework": "^102.0",
-        "magento/upward": "^1.0.0"
+        "magento/framework": "*",
+        "magento/upward": "*"
     },
     "type": "magento2-module",
     "license": [


### PR DESCRIPTION
### Description
**Issue**
A cloud environment that is deployed with core + pagebuilder git branches cannot also deploy a PWA git branch due to a compatibility issue in PWA's develop branch. 
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - magento/module-upward-connector 1.1.0 requires magento/framework ^102.0 -> no matching package found.
    - magento/module-upward-connector 1.1.0 requires magento/framework ^102.0 -> no matching package found.
    - Installation request for magento/module-upward-connector ~1.1.0 -> satisfiable by magento/module-upward-connector[1.1.0].
```

**Steps to Reproduce**
* Deploy a magento cloud environment with git branches for CE (2.3-develop), EE (2.3-develop), B2B (1.1-develop), PB (develop), PB-EE (develop), Inventory (1.1-develop)
* Deploy PWA develop branch to same cloud environment: https://wiki.corp.magento.com/display/COREENG/%5BCloud%5D+How-To+Deploy+PWA+Git+Branch
  * Composer update step will fail w/ above error

### Related Issue
* [[PWA-407](https://jira.corp.magento.com/browse/PWA-407)] Cannot Deploy PWA Develop & Core Develop (2.3-develop) Git Branches to Cloud Due to Composer Requirement Issue

### Notes
@dpatil-magento - This will require a small change to our release process, but we will follow more closely to how core performs their release. When we cut a release branch, we will then apply version constraints to our `composer.json` with the latest versions of `magento/framework` and `magento/upward`, probably maintain tilde or carat, so we aren't required to publish unless Magento does a major rev. Release steps would then be:
1. Merge `release` -> `master`
2. Tag release
3. Create branch from `master` (`revert-version-constraints`)
4. Add commit to revert version constraint
5. Merge into `develop`