### PR TITLE
[PWA-528] 2.4.0 Compatibility 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "~7.1.3||~7.2.0||~7.3.0",
+        "php": "~7.3.0||~7.4.0",
         "magento/framework": "*",
         "magento/upward": "*"
     },


### PR DESCRIPTION
### Description
Magento 2.4.0 will support PHP 7.4. PWA team need to analyze impact and see if any of our dependencies like upward-php, connector needs updates.

It would be good to start on this once 2.4.0-alpha package is available.

### Closes
* [[PWA-528](https://jira.corp.magento.com/browse/PWA-528)] PHP 7.4 support to analyze and test for PWA wrt Magento 2.4.0

### Dependent On
* magento-research/upward-php#81

### Verification Steps
1. Install latest available alpha/beta of Magento 2.4.0
2. `composer require magento/module-upward-connector:dev-tommy/240-compat`
3. Enable module and configure path to `upward.yml`
4. Verify that the PWA works (except for Braintree 😉 )