### PR TITLE
docs: use 'bypass list' instead of 'whitelist'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Use the absolute path on the server for the value of this configuration._
 
 Example: `/app/node_modules/@magento/venia-concept/dist/upward.yml`
 
-### Front Name Whitelist
+### Front Name Bypass List
 
 This configuration allows you to specify a line-separated list of routes to forward to the default Magento theme.
 

--- a/Test/Unit/Magento/Framework/App/AreaListTest.php
+++ b/Test/Unit/Magento/Framework/App/AreaListTest.php
@@ -69,8 +69,8 @@ class AreaListTest extends \PHPUnit\Framework\TestCase
         return [
             'Adminhtml area passes through' => ['adminhtml', '', 'adminhtml'],
             'Frontend area w/o frontname goes to UPWARD' => ['frontend', '', 'pwa'],
-            'Frontend area w/o frontname in whitelist goes to UPWARD' => ['frontend', 'baz', 'pwa'],
-            'Frontend area with frontname in whitelist passes through' => ['frontend', 'foo', 'frontend']
+            'Frontend area w/o frontname in bypass list goes to UPWARD' => ['frontend', 'baz', 'pwa'],
+            'Frontend area with frontname in bypass list passes through' => ['frontend', 'foo', 'frontend']
         ];
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -19,8 +19,8 @@
                     <comment>Server path to YAML configuration file for UPWARD</comment>
                 </field>
                 <field id="front_names_to_skip" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="30" translate="label,comment" type="textarea">
-                    <label>Front Name Whitelist</label>
-                    <comment>Line break separated list of URL's that will load the default Magento frontend.</comment>
+                    <label>Front Name Bypass List</label>
+                    <comment>Line break separated list of URLs that will bypass the connector and load the default Magento frontend.</comment>
                 </field>
             </group>
         </section>


### PR DESCRIPTION
Noticed some old deprecated terminology in the docs and tests, just thought I'd factor it out. Let me know if I did anything dumb!