### PR TITLE
Add support for a Header differentiating proxied and non proxied Requests to UPWARD-PHP

### DIFF
--- a/Plugin/Magento/Framework/App/AreaList.php
+++ b/Plugin/Magento/Framework/App/AreaList.php
@@ -9,9 +9,9 @@ declare(strict_types=1);
 namespace Magento\UpwardConnector\Plugin\Magento\Framework\App;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Request\Http as Request;
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\ScopeInterface;
-use Magento\Upward\Resolver\Proxy;
 use Magento\UpwardConnector\Api\UpwardPathManagerInterface;
 
 class AreaList
@@ -19,6 +19,11 @@ class AreaList
     public const UPWARD_HEADER = 'UpwardProxied';
 
     public const UPWARD_ENV_HEADER = 'UPWARD_PHP_PROXY_HEADER';
+
+    /**
+     * @var \Magento\Framework\App\Request\Http
+     */
+    private $request;
 
     /**
      * @var ScopeConfigInterface
@@ -36,13 +41,16 @@ class AreaList
     const UPWARD_CONFIG_PATH_FRONT_NAMES_TO_SKIP = 'web/upward/front_names_to_skip';
 
     /**
+     * @param Request $httpRequest
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\UpwardConnector\Api\UpwardPathManagerInterface|null $pathManager
      */
     public function __construct(
+        Request $httpRequest,
         ScopeConfigInterface $scopeConfig,
         ?UpwardPathManagerInterface $pathManager = null
     ) {
+        $this->request = $httpRequest;
         $this->scopeConfig = $scopeConfig;
         $this->pathManager = $pathManager ?: ObjectManager::getInstance()->get(UpwardPathManagerInterface::class);
     }
@@ -78,11 +86,10 @@ class AreaList
             ) ?? ''
         );
 
-        $request = new \Laminas\Http\PhpEnvironment\Request();
         $upwardProxyEnv = getenv(self::UPWARD_ENV_HEADER);
 
         /** $upwardProxyEnv needs to be truthy because getenv returns "false" if it didn't find it */
-        if ($upwardProxyEnv && $request->getHeader(self::UPWARD_HEADER) === $upwardProxyEnv) {
+        if ($upwardProxyEnv && $this->request->getHeader(self::UPWARD_HEADER) === $upwardProxyEnv) {
             return $result;
         }
 

--- a/Plugin/Magento/Framework/App/AreaList.php
+++ b/Plugin/Magento/Framework/App/AreaList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
@@ -10,10 +11,15 @@ namespace Magento\UpwardConnector\Plugin\Magento\Framework\App;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Upward\Resolver\Proxy;
 use Magento\UpwardConnector\Api\UpwardPathManagerInterface;
 
 class AreaList
 {
+    public const UPWARD_HEADER = 'UpwardProxied';
+
+    public const UPWARD_ENV_HEADER = 'UPWARD_PHP_PROXY_HEADER';
+
     /**
      * @var ScopeConfigInterface
      */
@@ -56,7 +62,6 @@ class AreaList
         $result,
         $frontName
     ) {
-
         if ($result !== 'frontend') {
             return $result;
         }
@@ -72,6 +77,14 @@ class AreaList
                 ScopeInterface::SCOPE_STORE
             ) ?? ''
         );
+
+        $request = new \Laminas\Http\PhpEnvironment\Request();
+        $upwardProxyEnv = getenv(self::UPWARD_ENV_HEADER);
+
+        /** $upwardProxyEnv needs to be truthy because getenv returns "false" if it didn't find it */
+        if ($upwardProxyEnv && $request->getHeader(self::UPWARD_HEADER) === $upwardProxyEnv) {
+            return $result;
+        }
 
         if ($frontName && in_array($frontName, $frontNamesToSkip)) {
             return $result;

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ The Magento 2 UPWARD connector has additional settings that can be configured in
 
 These are the configurations for the UPWARD process itself.
 
+#### UPWARD Environment variable
+
+This environment variable is meant to allow a secure way for Magento2 to distinguish a request which went through the UPWARD Proxy, and a "natural" request.
+
+```
+# bash
+export UPWARD_PHP_PROXY_HEADER='arbitrary_security_string' # preferably random, unique and longer than 16 characters
+
+# nginx conf
+fastcgi_param  UPWARD_PHP_PROXY_HEADER "arbitrary_security_string";
+
+```
+
+
 #### UPWARD Config File
 
 This configuration is the location of the UPWARD configuration file for the UPWARD-PHP server.


### PR DESCRIPTION
Part of the solution to #44 

If the new environment variable is not defined, the result is the same as previously.

Still requires the addition of said Header to https://github.com/magento/upward-php in the proxy request.